### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/playcard_server.py
+++ b/playcard_server.py
@@ -14,6 +14,7 @@ from flask_limiter.util import get_remote_address
 from difflib import get_close_matches
 from threading import Lock
 from werkzeug.middleware.proxy_fix import ProxyFix
+from werkzeug.utils import secure_filename
 
 # -------------------------------
 # Configuration (identisch zu PHP)
@@ -862,6 +863,7 @@ def get_current_radio_status():
 def serve_file(filename):
     """Identische Dateiauslieferung wie in PHP"""
     try:
+        filename = secure_filename(filename)
         filename = os.path.normpath(filename)
         for media_root in MEDIA_DIRS:
             full_path = os.path.normpath(os.path.join(media_root, filename))


### PR DESCRIPTION
Potential fix for [https://github.com/ArnoldSchiller/playcard/security/code-scanning/3](https://github.com/ArnoldSchiller/playcard/security/code-scanning/3)

To fix the issue, we need to ensure that the `filename` parameter is sanitized before constructing file paths. The best approach is to use `werkzeug.utils.secure_filename`, which removes special characters and ensures the filename is safe for use. This method is more restrictive and guarantees that filenames do not contain malicious patterns. Additionally, we will retain the normalization and directory containment checks to provide layered security.

**Steps to implement the fix:**
1. Import `secure_filename` from `werkzeug.utils`.
2. Apply `secure_filename` to the `filename` parameter before normalizing and constructing paths.
3. Retain the normalization and containment checks to ensure the constructed path is within the allowed directories.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
